### PR TITLE
Some fixes to watchr.rb and one improvement

### DIFF
--- a/scripts/watchr.rb
+++ b/scripts/watchr.rb
@@ -14,6 +14,12 @@ puts "String watchr... log file: #{log_file}"
 
 watch( '(app/js|test/unit)' )  do
   `echo "\n\ntest run started @ \`date\`" >> #{log_file}`
-  `scripts/test.sh >> #{log_file}`
+  testResults = `scripts/test.sh`
+  `echo "#{testResults}" >> #{log_file}`
+
+  if !(`which notify-send` == "") and testResults.index("Tests failed.")
+    `notify-send --urgency critical --icon dialog-warning "Test Failure!" "#{testResults}"`
+    abort(testResults)
+  end
 end
 


### PR DESCRIPTION
watchr.rb wasn't working for me at all, so I applied a few fixes.

Specifically:
- Removed the initial `cd ..` (I was getting an error message)
- Changed the ">" to ">>" in the logging statements so log will be appended
- Removed the "&" from the test execution logging statement, since its presence was causing nothing to get written to the log file for me.

I also updated the usage instructions to reflect the changes above.

Finally, I added support for desktop alerts on systems with libnotify-bin (notify-send command).  This means the developer can leave watchr.rb running and forget about it.  If they break a test, they'll get a desktop alert instead of having to tail the log file and keep an eye on it.
