### PR TITLE
Added global flag to path replace function in handleRequest

### DIFF
--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -86,7 +86,7 @@ StaticServlet.MimeMap = {
 
 StaticServlet.prototype.handleRequest = function(req, res) {
   var self = this;
-  var path = ('./' + req.url.pathname).replace('//','/').replace(/%(..)/, function(match, hex){
+  var path = ('./' + req.url.pathname).replace('//','/').replace(/%(..)/g, function(match, hex){
     return String.fromCharCode(parseInt(hex, 16));
   });
   var parts = path.split('/');


### PR DESCRIPTION
Simply added global flag to path replace function in handleRequest to allow more than one space (aka %20) in the name.

For eg:  If file is named index.html or index -onespace.html, this will work.  if it is named, index - twospaces.html, this will fail.

Apologies if I didn't do it right.  It's the first time I am using version control.  Usually, I just download the zip.
