### PR TITLE
web-server.js crashes on Node v0.8.0

### DIFF
--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-var sys = require('sys'),
+var sys = require('util'),
     http = require('http'),
     fs = require('fs'),
     url = require('url'),


### PR DESCRIPTION
The use of the 'sys' module inside the web-server.js produces an exception when running the web server on Node v0.8.0 because the that module have been deprecated. The issue is easily solved by replacing the 'sys' module with the 'util' module as explained in the following link: https://groups.google.com/forum/?fromgroups#!topic/nodejs/RMzvyNn0paw
