### PR TITLE
Added `pause` to test.bat to prevent command line window from closing

### DIFF
--- a/scripts/test.bat
+++ b/scripts/test.bat
@@ -12,3 +12,5 @@ java -jar "%BASE_DIR%\..\test\lib\jstestdriver\JsTestDriver.jar" ^
      --config "%BASE_DIR%\..\config\jsTestDriver.conf" ^
      --basePath "%BASE_DIR%\.." ^
      --tests all
+
+pause


### PR DESCRIPTION
Added `pause` to test.bat to prevent command line window from closing when launching/clicking test.bat from an IDE/Folder.
