### PR TITLE
added 'svg' MIME type to the web-server.js

### DIFF
--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -81,7 +81,8 @@ StaticServlet.MimeMap = {
   'jpg': 'image/jpeg',
   'jpeg': 'image/jpeg',
   'gif': 'image/gif',
-  'png': 'image/png'
+  'png': 'image/png',
+  'svg': 'image/svg+xml'
 };
 
 StaticServlet.prototype.handleRequest = function(req, res) {


### PR DESCRIPTION
Used web-server.js for app prototyping and noticed that It messes up svg's. Not ridiculously important, but quite annoying.
