### PR TITLE
Moved global controllers to module

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -2,9 +2,9 @@
 
 
 // Declare app level module which depends on filters, and services
-angular.module('myApp', ['myApp.filters', 'myApp.services', 'myApp.directives']).
+angular.module('myApp', ['myApp.filters', 'myApp.services', 'myApp.directives', 'myApp.controllers']).
   config(['$routeProvider', function($routeProvider) {
-    $routeProvider.when('/view1', {templateUrl: 'partials/partial1.html', controller: MyCtrl1});
-    $routeProvider.when('/view2', {templateUrl: 'partials/partial2.html', controller: MyCtrl2});
+    $routeProvider.when('/view1', {templateUrl: 'partials/partial1.html', controller: 'MyCtrl1'});
+    $routeProvider.when('/view2', {templateUrl: 'partials/partial2.html', controller: 'MyCtrl2'});
     $routeProvider.otherwise({redirectTo: '/view1'});
   }]);

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -2,11 +2,10 @@
 
 /* Controllers */
 
+angular.module('myApp.controllers', []).
+  controller('MyCtrl1', [function() {
 
-function MyCtrl1() {}
-MyCtrl1.$inject = [];
+  }])
+  .controller('MyCtrl2', [function() {
 
-
-function MyCtrl2() {
-}
-MyCtrl2.$inject = [];
+  }]);

--- a/test/unit/controllersSpec.js
+++ b/test/unit/controllersSpec.js
@@ -2,30 +2,15 @@
 
 /* jasmine specs for controllers go here */
 
-describe('MyCtrl1', function(){
-  var myCtrl1;
-
-  beforeEach(function(){
-    myCtrl1 = new MyCtrl1();
-  });
+describe('controllers', function(){
+  beforeEach(module('myApp.controllers'));
 
 
-  it('should ....', function() {
+  it('should ....', inject(function() {
     //spec body
-  });
-});
+  }));
 
-
-describe('MyCtrl2', function(){
-  var myCtrl2;
-
-
-  beforeEach(function(){
-    myCtrl2 = new MyCtrl2();
-  });
-
-
-  it('should ....', function() {
+  it('should ....', inject(function() {
     //spec body
-  });
+  }));
 });


### PR DESCRIPTION
The current developers guide advises against using global scope functions as controllers, because of this I have moved it to a module. I feel this also ties in better with how filters, directives and services are defined.

The following reference is seen on this url http://docs.angularjs.org/guide/dev_guide.mvc.understanding_controller

**NOTE**: Many of the examples in the documentation show the creation of functions in the global scope. This is only for demonstration purposes - in a real application you should use the .controller method of your Angular module for your application as follows:
