### PR TITLE
Escape single quotes

### DIFF
--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -19,7 +19,8 @@ function escapeHtml(value) {
   return value.toString().
     replace('<', '&lt;').
     replace('>', '&gt;').
-    replace('"', '&quot;');
+    replace('"', '&quot;').
+    replace("'", '&#39;');
 }
 
 function createServlet(Class) {


### PR DESCRIPTION
Any HTML escape routines must escape single quotes as these are commonly and validly used to delimit attribute values, and thus can be abused to create an XSS attack.
