### PR TITLE
Made controllersSpec easier to understand

### DIFF
--- a/test/unit/controllersSpec.js
+++ b/test/unit/controllersSpec.js
@@ -6,11 +6,15 @@ describe('controllers', function(){
   beforeEach(module('myApp.controllers'));
 
 
-  it('should ....', inject(function() {
+  it('should ....', inject(function($controller) {
     //spec body
+    var myCtrl1 = $controller('MyCtrl1');
+    expect(myCtrl1).toBeDefined();
   }));
 
-  it('should ....', inject(function() {
+  it('should ....', inject(function($controller) {
     //spec body
+    var myCtrl2 = $controller('MyCtrl2');
+    expect(myCtrl2).toBeDefined();
   }));
 });


### PR DESCRIPTION
It wasn't obvious at first how to get a controller when you needed one. Updated the spec to include a call to `$controller` to fetch the controller needed.
