### PR TITLE
change the configuration file for karma-e2e conf

### DIFF
--- a/config/karma-e2e.conf.js
+++ b/config/karma-e2e.conf.js
@@ -8,6 +8,8 @@ files = [
 
 autoWatch = false;
 
+urlRoot = '/angular-seed/'
+
 browsers = ['Chrome'];
 
 singleRun = true;


### PR DESCRIPTION
Without the urlRoot, it keeps throwing the error '/' has been proxied you should probably use 'urlRoot' to avoid conflicts. 

With this change, the error goes away and the tests run
