### PR TITLE
Fix angular name typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "angualrjs-seed",
+  "name": "angularjs-seed",
   "description": "A starter project for angular js",
   "devDependencies": {
         "phantomjs" : "*",


### PR DESCRIPTION
"angularjs-seed" was mistyped in package.json. This fix corrects this typo.
