### PR TITLE
Fixes #109.

### DIFF
--- a/app/index-async.html
+++ b/app/index-async.html
@@ -7,17 +7,8 @@
       display: none;
     }
   </style>
+  <script src='lib/angular/angular.js'></script>
   <script>
-    // include angular loader, which allows the files to load in any order
-    /*
-     AngularJS v1.0.7
-     (c) 2010-2012 Google, Inc. http://angularjs.org
-     License: MIT
-    */
-    (function(i){'use strict';function d(c,b,e){return c[b]||(c[b]=e())}return d(d(i,"angular",Object),"module",function(){var c={};return function(b,e,f){e&&c.hasOwnProperty(b)&&(c[b]=null);return d(c,b,function(){function a(a,b,d){return function(){c[d||"push"]([a,b,arguments]);return g}}if(!e)throw Error("No module: "+b);var c=[],d=[],h=a("$injector","invoke"),g={_invokeQueue:c,_runBlocks:d,requires:e,name:b,provider:a("$provide","provider"),factory:a("$provide","factory"),service:a("$provide","service"),
-    value:a("$provide","value"),constant:a("$provide","constant","unshift"),filter:a("$filterProvider","register"),controller:a("$controllerProvider","register"),directive:a("$compileProvider","directive"),config:h,run:function(a){d.push(a);return this}};f&&h(f);return g})}})})(window);
-
-
     // include a third-party async loader library
     /*!
      * $script.js v1.3
@@ -30,7 +21,7 @@
 
     // load all of the dependencies asynchronously.
     $script([
-      'lib/angular/angular.js',
+      'lib/angular/angular-route.js',
       'js/app.js',
       'js/services.js',
       'js/controllers.js',


### PR DESCRIPTION
Some modules (read angular-ui-router) require more than the angular.module method (angular.extend, etc.) to run.  Loading angular.js synchronously (and thus making the full library available to the other scripts, which are loading asynchronously) will prevent errors such as these: https://github.com/angular-ui/ui-router/issues/232.  Also, this file is missing a reference to angular-route.js.
