### PR TITLE
Fixing variable

### DIFF
--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -191,8 +191,8 @@ StaticServlet.prototype.sendDirectory_ = function(req, res, path) {
     var redirectUrl = url.format(url.parse(url.format(req.url)));
     return self.sendRedirect_(req, res, redirectUrl);
   }
-  fs.readdir(path, function(err, files) {
-    if (err)
+  fs.readdir(path, function(error, files) {
+    if (error)
       return self.sendError_(req, res, error);
 
     if (!files.length)


### PR DESCRIPTION
"error" is undefined, but "err" is what we really wanted to pass.  Instead of using "err" in the function call, I renamed the "err" variable to match other usages of `.sendError_()`
