### PR TITLE
Karma should be loaded from the path - not a relative directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ We recommend using [jasmine](http://pivotal.github.com/jasmine/) and
 to use whatever works for you.
 
 Requires [node.js](http://nodejs.org/), Karma (`sudo npm install -g karma`) and a local
-or remote browser.
+or remote browser. Ensure karma is on your PATH (it would typically be installed in: node_modules/karma/bin/karma).
 
 * start `scripts/test.sh` (on windows: `scripts\test.bat`)
   * a browser will start and connect to the Karma server (Chrome is default browser, others can be captured by loading the same url as the one in Chrome or by changing the `config/karma.conf.js` file)

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -7,4 +7,4 @@ echo "Starting Karma Server (http://karma-runner.github.io)"
 echo $BASE_DIR
 echo "-------------------------------------------------------------------"
 
-$BASE_DIR/../node_modules/karma/bin/karma start $BASE_DIR/../config/karma-e2e.conf.js $*
+karma start $BASE_DIR/../config/karma-e2e.conf.js $*

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -6,4 +6,4 @@ echo ""
 echo "Starting Karma Server (http://karma-runner.github.io)"
 echo "-------------------------------------------------------------------"
 
-$BASE_DIR/../node_modules/karma/bin/karma start $BASE_DIR/../config/karma.conf.js $*
+karma start $BASE_DIR/../config/karma.conf.js $*


### PR DESCRIPTION
People can install karma in many places - assuming relative to the script directory seems "odd" to me. 
