### PR TITLE
fix(web-server): bind only to localhost

### DIFF
--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -40,7 +40,7 @@ function HttpServer(handlers) {
 
 HttpServer.prototype.start = function(port) {
   this.port = port;
-  this.server.listen(port);
+  this.server.listen(port, 'localhost');
   util.puts('Http Server running at http://localhost:' + port + '/');
 };
 


### PR DESCRIPTION
It's better to bind to localhost only during development, since it improves security. It also avoids a pesky warning under Mac OS.
