### PR TITLE
Wrong example of installing karma

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ We recommend using [jasmine](http://pivotal.github.com/jasmine/) and
 [Karma](http://karma-runner.github.io) for your unit tests/specs, but you are free
 to use whatever works for you.
 
-Requires [node.js](http://nodejs.org/), Karma (`sudo npm install -g karma`) and a local
+Requires [node.js](http://nodejs.org/), Karma (`sudo npm install karma`) and a local
 or remote browser.
 
 * start `scripts/test.sh` (on windows: `scripts\test.bat`)


### PR DESCRIPTION
The karma should be installed locally to the project because in this case the `test.sh` script doesn't work. It assumes that module will be in the project folder but actually the module is installed to the system path.
