### PR TITLE
Fixed e2e-test.bat from terminating prematurely

### DIFF
--- a/scripts/e2e-test.bat
+++ b/scripts/e2e-test.bat
@@ -8,5 +8,5 @@ REM - NodeJS (http://nodejs.org/)
 REM - Protractor (npm install -g protractor)
 
 set BASE_DIR=%~dp0
-webdriver-manager update
-protractor "%BASE_DIR%\..\config\protractor-conf.js" %*
+call webdriver-manager update
+call protractor "%BASE_DIR%\..\config\protractor-conf.js" %*


### PR DESCRIPTION
I believe I was encountering the issue described here: https://github.com/npm/npm/issues/2938 when running e2e-test.bat.  After the webdrive update the batch would just stop.  This only showed up after the protractor change because we're now calling two separate node scripts versus just one when using karma.
