### PR TITLE
fix(web-server): bind only to localhost

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "postinstall": "bower install",
 
-    "start": "http-server -p 8000",
+    "start": "http-server -a localhost -p 8000",
     "test": "karma start test/karma.conf.js",
 
     "update-webdriver": "webdriver-manager update",


### PR DESCRIPTION
It's better to bind to localhost only during development, since it improves security. It also avoids a pesky warning under Mac OS.
