### PR TITLE
Fixes path for bower_components in karma file list

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -4,9 +4,9 @@ module.exports = function(config){
     basePath : '../',
 
     files : [
-      'bower_components/angular/angular.js',
-      'bower_components/angular-route/angular-route.js',
-      'bower_components/angular-mocks/angular-mocks.js',
+      'app/bower_components/angular/angular.js',
+      'app/bower_components/angular-route/angular-route.js',
+      'app/bower_components/angular-mocks/angular-mocks.js',
       'app/js/**/*.js',
       'test/unit/**/*.js'
     ],


### PR DESCRIPTION
The `basePath` is set to `../` (from `./test`) but bower_components are in `./app/bower_components`.
