### PR TITLE
need to 'karma-junit-reporter’ in plugins for reporter to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "protractor": "~0.17.0",
     "http-server": "^0.6.1",
     "bower": "^1.3.1",
-    "shelljs": "^0.2.6"
+    "shelljs": "^0.2.6",
+    "karma-junit-reporter": "^0.2.2"
   },
   "scripts": {
     "postinstall": "bower install",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -20,7 +20,8 @@ module.exports = function(config){
     plugins : [
             'karma-chrome-launcher',
             'karma-firefox-launcher',
-            'karma-jasmine'
+            'karma-jasmine',
+            'karma-junit-reporter'
             ],
 
     junitReporter : {


### PR DESCRIPTION
without this - if you try to use the junit reporter, it will fail due to missing module (even if installed outside).
