### PR TITLE
bower installs components to the app directory

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -18,8 +18,8 @@
   <!-- In production use:
   <script src="//ajax.googleapis.com/ajax/libs/angularjs/x.x.x/angular.min.js"></script>
   -->
-  <script src="../bower_components/angular/angular.js"></script>
-  <script src="../bower_components/angular-route/angular-route.js"></script>
+  <script src="../app/bower_components/angular/angular.js"></script>
+  <script src="../app/bower_components/angular-route/angular-route.js"></script>
   <script src="js/app.js"></script>
   <script src="js/services.js"></script>
   <script src="js/controllers.js"></script>


### PR DESCRIPTION
When going to http://localhost:8000/app the application was failing to find the installed bower_components directory.

When running npm test I was getting the same error.  I changed the reference to point to where bower installs it's components now ../app/bower_components.

An alternative would be to add a .bowerrc file and change where bower installs it's components to the root directory of the project.
