### PR TITLE
Remove invalid path references in index.html

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,10 +9,10 @@
   <title>My AngularJS App</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="../bower_components/html5-boilerplate/css/normalize.css">
-  <link rel="stylesheet" href="../bower_components/html5-boilerplate/css/main.css">
+  <link rel="stylesheet" href="bower_components/html5-boilerplate/css/normalize.css">
+  <link rel="stylesheet" href="bower_components/html5-boilerplate/css/main.css">
   <link rel="stylesheet" href="css/app.css"/>
-  <script src="../bower_components/html5-boilerplate/js/vendor/modernizr-2.6.2.min.js"></script>
+  <script src="bower_components/html5-boilerplate/js/vendor/modernizr-2.6.2.min.js"></script>
 </head>
 <body>
   <ul class="menu">


### PR DESCRIPTION
A few invalid paths which were referenced in index.html were removed.  These paths became invalid due to commit daf71f27ba1ae0801f0f3235eaa87598f0912a59 which moved where the bower_components directory is placed.
