### PR TITLE
Remove local HTTP server's cache-control header.

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "postinstall": "bower install",
 
     "prestart": "npm install",
-    "start": "http-server -a localhost -p 8000",
+    "start": "http-server -a localhost -p 8000 -c-1",
 
     "pretest": "npm install",
     "test": "karma start test/karma.conf.js",


### PR DESCRIPTION
Disable the local HTTP server's cache-control header, to fix the problem where the browser wouldn't reload templateUrl-based directive templates. Fixes #193.
