### PR TITLE
Fix link to protractor tutorial

### DIFF
--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -1,6 +1,6 @@
 'use strict';
 
-/* https://github.com/angular/protractor/blob/master/docs/getting-started.md */
+/* https://github.com/angular/protractor/blob/master/docs/toc.md */
 
 describe('my app', function() {
 


### PR DESCRIPTION
Link https://github.com/angular/protractor/blob/master/docs/getting-started.md doesn't exists
