### PR TITLE
fix(travis): node js version should between quote

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.10
+  - "0.10"
 
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
node js version should between quotation marks based on http://docs.travis-ci.com/user/languages/javascript-with-nodejs/

this my error build before https://travis-ci.org/saiqulhaq/kalkulator-ipk/builds/31290985
and this is success build after i put quotation https://travis-ci.org/saiqulhaq/kalkulator-ipk/builds/31291571
