### PR TITLE
bower.json: bump Angular dependencies to 1.3.x.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "1.2.x",
-    "angular-route": "1.2.x",
-    "angular-loader": "1.2.x",
-    "angular-mocks": "~1.2.x",
+    "angular": "1.3.x",
+    "angular-route": "1.3.x",
+    "angular-loader": "1.3.x",
+    "angular-mocks": "~1.3.x",
     "html5-boilerplate": "~4.3.0"
   }
 }


### PR DESCRIPTION
The seed project should reflect that AngularJS 1.3.0 has recently been released. The unit tests and the end to end tests succeed with the changes proposed.