### PR TITLE
Update Angular dependency to ~1.3.0, update html5-boilerplate, karma

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,10 +9,10 @@
   <title>My AngularJS App</title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="bower_components/html5-boilerplate/css/normalize.css">
-  <link rel="stylesheet" href="bower_components/html5-boilerplate/css/main.css">
+  <link rel="stylesheet" href="bower_components/html5-boilerplate/dist/css/normalize.css">
+  <link rel="stylesheet" href="bower_components/html5-boilerplate/dist/css/main.css">
   <link rel="stylesheet" href="app.css">
-  <script src="bower_components/html5-boilerplate/js/vendor/modernizr-2.6.2.min.js"></script>
+  <script src="bower_components/html5-boilerplate/dist/js/vendor/modernizr-2.8.3.min.js"></script>
 </head>
 <body>
   <ul class="menu">

--- a/bower.json
+++ b/bower.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "1.2.x",
-    "angular-route": "1.2.x",
-    "angular-loader": "1.2.x",
-    "angular-mocks": "~1.2.x",
-    "html5-boilerplate": "~4.3.0"
+    "angular": "1.3.x",
+    "angular-route": "1.3.x",
+    "angular-loader": "1.3.x",
+    "angular-mocks": "~1.3.x",
+    "html5-boilerplate": "~5.2.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "1.3.x",
-    "angular-route": "1.3.x",
-    "angular-loader": "1.3.x",
-    "angular-mocks": "~1.3.x",
+    "angular": "~1.3.0",
+    "angular-route": "~1.3.0",
+    "angular-loader": "~1.3.0",
+    "angular-mocks": "~1.3.0",
     "html5-boilerplate": "~5.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,12 +6,16 @@
   "repository": "https://github.com/angular/angular-seed",
   "license": "MIT",
   "devDependencies": {
-    "karma": "~0.10",
-    "protractor": "^1.1.1",
-    "http-server": "^0.6.1",
     "bower": "^1.3.1",
-    "shelljs": "^0.2.6",
-    "karma-junit-reporter": "^0.2.2"
+    "http-server": "^0.6.1",
+    "jasmine-core": "^2.3.4",
+    "karma": "~0.12",
+    "karma-chrome-launcher": "^0.1.12",
+    "karma-firefox-launcher": "^0.1.6",
+    "karma-jasmine": "^0.3.5",
+    "karma-junit-reporter": "^0.2.2",
+    "protractor": "^1.1.1",
+    "shelljs": "^0.2.6"
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
I think angular-seed project should always be updated with the latest _stable_ version of Angular as a dependency, so I've updated the dependency version to `~1.3.0` (similar and to be consistent with [what's suggested on the tutorial](https://docs.angularjs.org/tutorial/step_11)) on `bower.json`.

Fixes #259.

Additionally, I've updated the `html5-boilerplate` dependency to the latest version and updated the `src` of scripts/css on `index.html`.

I was also running into issues on `npm install` and updated `karma` to the latest version as well, and added all the needed karma plugins. (I think this may also solve other `npm install` issues such as #271, #270, #266, #263 and #262.)

I've checked the migration guide but no change to the code was needed. I've tested the seed project with this new version and have run all the tests successfully.