### PR TITLE
chore: update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.10"
+  - '4.4'
 
 before_script:
   - export DISPLAY=:99.0

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ this server is:
 npm start
 ```
 
-Now browse to the app at `http://localhost:8000/app/index.html`.
+Now browse to the app at `http://localhost:8000/index.html`.
 
 
 

--- a/bower.json
+++ b/bower.json
@@ -6,10 +6,10 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "angular": "~1.4.0",
-    "angular-route": "~1.4.0",
-    "angular-loader": "~1.4.0",
-    "angular-mocks": "~1.4.0",
-    "html5-boilerplate": "~5.2.0"
+    "angular": "~1.5.0",
+    "angular-loader": "~1.5.0",
+    "angular-mocks": "~1.5.0",
+    "angular-route": "~1.5.0",
+    "html5-boilerplate": "^5.0"
   }
 }

--- a/e2e-tests/protractor.conf.js
+++ b/e2e-tests/protractor.conf.js
@@ -9,7 +9,7 @@ exports.config = {
     'browserName': 'chrome'
   },
 
-  baseUrl: 'http://localhost:8000/app/',
+  baseUrl: 'http://localhost:8000/',
 
   framework: 'jasmine',
 

--- a/package.json
+++ b/package.json
@@ -21,11 +21,11 @@
     "postinstall": "bower install",
 
     "prestart": "npm install",
-    "start": "http-server -a localhost -p 8000 -c-1",
+    "start": "http-server -a localhost -p 8000 -c-1 ./app",
 
     "pretest": "npm install",
     "test": "karma start karma.conf.js",
-    "test-single-run": "karma start karma.conf.js  --single-run",
+    "test-single-run": "karma start karma.conf.js --single-run",
 
     "preupdate-webdriver": "npm install",
     "update-webdriver": "webdriver-manager update",

--- a/package.json
+++ b/package.json
@@ -6,16 +6,16 @@
   "repository": "https://github.com/angular/angular-seed",
   "license": "MIT",
   "devDependencies": {
-    "bower": "^1.3.1",
-    "http-server": "^0.6.1",
-    "jasmine-core": "^2.3.4",
-    "karma": "~0.12",
-    "karma-chrome-launcher": "^0.1.12",
-    "karma-firefox-launcher": "^0.1.6",
-    "karma-jasmine": "^0.3.5",
-    "karma-junit-reporter": "^0.2.2",
-    "protractor": "^2.1.0",
-    "shelljs": "^0.2.6"
+    "bower": "^1.7.7",
+    "http-server": "^0.9.0",
+    "jasmine-core": "^2.4.1",
+    "karma": "^0.13.22",
+    "karma-chrome-launcher": "^0.2.3",
+    "karma-firefox-launcher": "^0.1.7",
+    "karma-jasmine": "^0.3.8",
+    "karma-junit-reporter": "^0.4.1",
+    "protractor": "^3.2.2",
+    "shelljs": "^0.6.0"
   },
   "scripts": {
     "postinstall": "bower install",


### PR DESCRIPTION
Updated both `bower` and `npm` dependencies to latest versions. Most notably `angular`, `karma`, `protractor` and `http-server`. Note that some older versions of `http-server` (and transitively `karma`) threw errors on Windows with non-english locales. 

Tested all scripts with node versions `4.4.0` and `5.9.0` (on Windows 10) and everything seems to work as expected.

--
There is also a 2nd (optional) commit that changes the served folder to `./app` (instead of the project root). I think it makes sense, but I may have missed the reasoning for the original decision.