### PR TITLE
More efficient way to style menu items seperator

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -19,12 +19,7 @@
   display: inline;
 }
 
-.menu > li:before {
+.menu > li + li:before {
   content: "|";
   padding-right: 0.3em;
-}
-
-.menu > li:nth-child(1):before {
-  content: "";
-  padding: 0;
 }


### PR DESCRIPTION
Using CSS selector + in order to skip first item, instead style all items and restyle first item using nth-child
* tested successfully with one item, two, and more.